### PR TITLE
feat: Add interactive LLM advice pane

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ A terminal-based user interface (TUI) for monitoring git repositories in real-ti
 
 ### LLM Advice
 - `j` / `k` - Scroll up/down
+- `/` - Enter input mode to ask a question
+- `Enter` - Submit the question to the LLM
+- `Esc` - Exit input mode
 
 ## Installation
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -156,6 +156,9 @@ async fn main() -> Result<()> {
             }
         }
 
+        // Poll for LLM advice responses
+        app.poll_llm_advice();
+
         // Calculate monitor visible height before rendering
         let terminal_size = terminal.size()?;
         let terminal_rect =

--- a/src/main.rs
+++ b/src/main.rs
@@ -136,6 +136,9 @@ async fn main() -> Result<()> {
             app.update_monitor_timing(elapsed, has_run);
         }
 
+        // Poll for LLM advice responses
+        app.poll_llm_advice();
+
         // Update llm command if it exists
         if let Some(ref mut llm) = llm_command {
             if let Some(repo) = &git_repo.repo {
@@ -155,9 +158,6 @@ async fn main() -> Result<()> {
                 }
             }
         }
-
-        // Poll for LLM advice responses
-        app.poll_llm_advice();
 
         // Calculate monitor visible height before rendering
         let terminal_size = terminal.size()?;
@@ -267,6 +267,12 @@ async fn main() -> Result<()> {
 }
 
 fn handle_key_event(key: KeyEvent, app: &mut App) -> bool {
+    if app.is_showing_advice_pane() {
+        if app.forward_key_to_panes(key) {
+            return false;
+        }
+    }
+
     match key.code {
         KeyCode::Char('q') => {
             log::info!("User requested quit");

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -928,7 +928,6 @@ impl AdvicePane {
                         tool_calls: None,
                         tool_call_id: None,
                     });
-                    self.scroll_offset = usize::MAX;
                 }
                 Err(e) => {
                     self.content.push_str("\n\nError: ");

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -928,6 +928,7 @@ impl AdvicePane {
                         tool_calls: None,
                         tool_call_id: None,
                     });
+                    self.scroll_offset = usize::MAX;
                 }
                 Err(e) => {
                     self.content.push_str("\n\nError: ");

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -768,6 +768,15 @@ impl App {
     pub fn get_last_active_pane(&self) -> ActivePane {
         self.last_active_pane
     }
+
+    pub fn poll_llm_advice(&mut self) {
+        self.pane_registry
+            .with_pane_mut(&PaneId::Advice, |pane| {
+                if let Some(advice_pane) = pane.as_advice_pane_mut() {
+                    advice_pane.poll_llm_response();
+                }
+            });
+    }
 }
 
 #[allow(clippy::extra_unused_type_parameters)]


### PR DESCRIPTION
This commit introduces an interactive mode to the LLM advice pane, allowing users to ask follow-up questions and have a conversation with the LLM.

Key features:
- Press '/' in the LLM advice pane to enter input mode.
- A single-line input box appears at the bottom of the pane.
- Users can type questions, and the input box supports basic editing (backspace, left/right arrows).
- Pressing 'Enter' sends the question to the LLM, including the previous conversation history and the initial diff context.
- A "Loading..." message is displayed while waiting for the LLM response.
- Pressing 'Esc' exits input mode.
- The conversation history is maintained for the current session.
- The help pane and README.md have been updated to reflect the new keybindings.

Implementation details:
- The `AdvicePane` now manages state for input mode, user input, conversation history, and asynchronous LLM communication.
- A new `get_llm_advice` async function has been added to `src/llm.rs` to handle on-demand API calls to OpenAI.
- The main application loop now polls for LLM responses to prevent blocking the UI thread.
- The initial `DataUpdated` event now correctly primes the conversation with a system prompt and the initial data, and triggers the initial LLM call.