### PR TITLE
Refactor LLM handling to use a single, shared client

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -23,5 +23,5 @@ fn main() {
         "unknown".to_string()
     };
 
-    writeln!(&mut f, "pub const GIT_SHA: &str = \"{}\";", git_sha).unwrap();
+    writeln!(&mut f, "pub const GIT_SHA: &str = \"{git_sha}\";").unwrap();
 }

--- a/src/git_worker.rs
+++ b/src/git_worker.rs
@@ -80,7 +80,7 @@ impl GitWorker {
         let mut new_staged_files = Vec::new();
         let mut new_dirty_directory_files = Vec::new();
         let status_count = statuses.len();
-        debug!("Found {} total status entries", status_count);
+        debug!("Found {status_count} total status entries");
 
         for status in statuses.iter() {
             let path = status.path().unwrap_or("");
@@ -119,7 +119,7 @@ impl GitWorker {
             // Dirty directory detection (files that would be shown by git diff --name-only)
             if self.is_file_in_dirty_directory(&file_path) {
                 let diff = self.get_dirty_directory_diff(&file_path);
-                debug!("Processing dirty directory file: {}", path);
+                debug!("Processing dirty directory file: {path}");
                 new_dirty_directory_files.push(diff);
             }
         }
@@ -153,7 +153,7 @@ impl GitWorker {
     }
 
     fn get_file_diff(&self, path: &Path, status: Status) -> FileDiff {
-        debug!("Computing diff for file: {:?} (status: {:?})", path, status);
+        debug!("Computing diff for file: {path:?} (status: {status:?})");
 
         let mut line_strings = Vec::new();
         let mut additions = 0;
@@ -162,7 +162,7 @@ impl GitWorker {
         if status.is_wt_new() {
             if let Ok(content) = std::fs::read_to_string(path) {
                 let line_count = content.lines().count();
-                debug!("New file has {} lines", line_count);
+                debug!("New file has {line_count} lines");
                 for line in content.lines() {
                     line_strings.push(format!("+ {line}"));
                     additions += 1;
@@ -182,7 +182,7 @@ impl GitWorker {
                     }
                     line_strings.push(line.to_string());
                 }
-                debug!("Modified file: +{} -{}", additions, deletions);
+                debug!("Modified file: +{additions} -{deletions}");
             }
         } else if status.is_wt_deleted()
             && let Ok(output) = std::process::Command::new("git")
@@ -196,7 +196,7 @@ impl GitWorker {
                 }
                 line_strings.push(line.to_string());
             }
-            debug!("Deleted file: -{} lines", deletions);
+            debug!("Deleted file: -{deletions} lines");
         }
 
         FileDiff {
@@ -210,8 +210,7 @@ impl GitWorker {
 
     fn get_staged_file_diff(&self, path: &Path, status: Status) -> FileDiff {
         debug!(
-            "Computing staged diff for file: {:?} (status: {:?})",
-            path, status
+            "Computing staged diff for file: {path:?} (status: {status:?})"
         );
 
         let mut line_strings = Vec::new();
@@ -237,7 +236,7 @@ impl GitWorker {
                 }
                 line_strings.push(line.to_string());
             }
-            debug!("Staged file: +{} -{}", additions, deletions);
+            debug!("Staged file: +{additions} -{deletions}");
         }
 
         FileDiff {
@@ -250,7 +249,7 @@ impl GitWorker {
     }
 
     fn get_dirty_directory_diff(&self, path: &Path) -> FileDiff {
-        debug!("Computing dirty directory diff for file: {:?}", path);
+        debug!("Computing dirty directory diff for file: {path:?}");
 
         let mut line_strings = Vec::new();
         let mut additions = 0;
@@ -270,7 +269,7 @@ impl GitWorker {
                 }
                 line_strings.push(line.to_string());
             }
-            debug!("Dirty directory file: +{} -{}", additions, deletions);
+            debug!("Dirty directory file: +{additions} -{deletions}");
         }
 
         FileDiff {

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -37,7 +37,7 @@ pub fn init_logging(debug: bool) -> Result<()> {
         })
         .init();
 
-    log::info!("Logging initialized with level: {}", log_level);
+    log::info!("Logging initialized with level: {log_level}");
     Ok(())
 }
 

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -33,7 +33,7 @@ impl AsyncMonitorCommand {
                 };
 
                 if should_run {
-                    debug!("Running async monitor command: {}", command_clone);
+                    debug!("Running async monitor command: {command_clone}");
 
                     let result = if cfg!(target_os = "windows") {
                         AsyncCommand::new("cmd")
@@ -54,9 +54,9 @@ impl AsyncMonitorCommand {
 
                             if output.status.success() {
                                 let output_str = if stderr.is_empty() {
-                                    format!("$ {}\n{}", command_clone, stdout)
+                                    format!("$ {command_clone}\n{stdout}")
                                 } else {
-                                    format!("$ {}\n{}\n{}", command_clone, stdout, stderr)
+                                    format!("$ {command_clone}\n{stdout}\n{stderr}")
                                 };
 
                                 if result_tx
@@ -69,8 +69,7 @@ impl AsyncMonitorCommand {
                                 debug!("Async monitor command completed successfully");
                             } else {
                                 let error_str = format!(
-                                    "$ {}\nCommand failed: {}\n{}",
-                                    command_clone, stderr, stdout
+                                    "$ {command_clone}\nCommand failed: {stderr}\n{stdout}"
                                 );
 
                                 if result_tx
@@ -80,12 +79,12 @@ impl AsyncMonitorCommand {
                                 {
                                     break; // Channel closed, stop the task
                                 }
-                                debug!("Async monitor command failed: {}", stderr);
+                                debug!("Async monitor command failed: {stderr}");
                             }
                         }
                         Err(e) => {
                             let error_str =
-                                format!("$ {}\nCommand execution failed: {}", command_clone, e);
+                                format!("$ {command_clone}\nCommand execution failed: {e}");
 
                             if result_tx
                                 .send(MonitorResult::Error(error_str))
@@ -94,7 +93,7 @@ impl AsyncMonitorCommand {
                             {
                                 break; // Channel closed, stop the task
                             }
-                            debug!("Async monitor command execution error: {}", e);
+                            debug!("Async monitor command execution error: {e}");
                         }
                     }
 


### PR DESCRIPTION
This commit refactors the LLM handling to use a single `LlmClient` instance that is created at startup and shared across the application. This avoids creating a new OpenAI client for each request.

The `LlmClient` is configured to use the model specified in the `llm_config`, and defaults to `gpt-5-mini` if the model is not specified.

A new `base_url` option has been added to the `llm_config` to allow for custom OpenAI-compatible API endpoints.

The `OpenAIClient` is now wrapped in an `Arc<Mutex<>>` to ensure thread-safe access across async tasks.