### PR TITLE
🔒 Fix: Redact sensitive LlmConfig fields in logs

### DIFF
--- a/src/llm.rs
+++ b/src/llm.rs
@@ -23,9 +23,16 @@ pub struct LlmClient {
 
 impl LlmClient {
     pub fn new(config: LlmConfig) -> Result<Self, String> {
+        // Create a redacted clone for logging to ensure secrets are never leaked
+        // even if the Debug implementation of LlmConfig changes.
+        let mut log_config = config.clone();
+        if log_config.api_key.is_some() {
+            log_config.api_key = Some("REDACTED".to_string());
+        }
+
         debug!(
             "🤖 LLM_CLIENT: Creating new client with config: {:?}",
-            config
+            log_config
         );
 
         let api_key = config


### PR DESCRIPTION
This PR fixes a security vulnerability where `LlmConfig` was being logged using `debug!`, potentially exposing sensitive information like API keys.

Although `LlmConfig` currently has a manual `Debug` implementation that redacts the API key, this PR adds an extra layer of security by explicitly creating a redacted clone of the configuration before logging it. This ensures that even if the `Debug` implementation of `LlmConfig` is modified or removed in the future (e.g., reverting to `derive(Debug)`), the secrets will not be leaked in this log statement.

Testing:
- Verified that existing tests pass (`cargo test`).
- Verified that the `LlmClient::new` function works correctly with the change.

---
*PR created automatically by Jules for task [10474778031711846422](https://jules.google.com/task/10474778031711846422) started by @myaple*